### PR TITLE
Job scheduling tweaks

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -11,4 +11,4 @@ builds:
   - -s
   - -w
   - -extldflags "-static"
-  - -X github.com/buildkite/agent-stack-k8s/v2/internal/version.version={{.Env.VERSION}}
+  - -X github.com/buildkite/agent-stack-k8s/v2/internal/version.version=0.21.0

--- a/api/generated.go
+++ b/api/generated.go
@@ -1642,7 +1642,7 @@ fragment Build on Build {
 	id
 	number
 	state
-	jobs(first: 100) {
+	jobs(first: 500) {
 		edges {
 			node {
 				__typename
@@ -1738,7 +1738,7 @@ fragment Build on Build {
 	id
 	number
 	state
-	jobs(first: 100) {
+	jobs(first: 500) {
 		edges {
 			node {
 				__typename
@@ -1805,7 +1805,7 @@ fragment Build on Build {
 	id
 	number
 	state
-	jobs(first: 100) {
+	jobs(first: 500) {
 		edges {
 			node {
 				__typename
@@ -1937,7 +1937,7 @@ const GetScheduledJobs_Operation = `
 query GetScheduledJobs ($slug: ID!, $agentQueryRules: [String!]) {
 	organization(slug: $slug) {
 		id
-		jobs(state: [SCHEDULED], type: [COMMAND], first: 100, order: RECENTLY_ASSIGNED, agentQueryRules: $agentQueryRules, clustered: false) {
+		jobs(state: [SCHEDULED], type: [COMMAND], first: 500, order: RECENTLY_ASSIGNED, agentQueryRules: $agentQueryRules, clustered: false) {
 			count
 			edges {
 				node {
@@ -1995,7 +1995,7 @@ const GetScheduledJobsClustered_Operation = `
 query GetScheduledJobsClustered ($slug: ID!, $agentQueryRules: [String!], $cluster: ID!) {
 	organization(slug: $slug) {
 		id
-		jobs(state: [SCHEDULED], type: [COMMAND], first: 100, order: RECENTLY_ASSIGNED, agentQueryRules: $agentQueryRules, cluster: $cluster) {
+		jobs(state: [SCHEDULED], type: [COMMAND], first: 250, order: RECENTLY_ASSIGNED, agentQueryRules: $agentQueryRules, cluster: $cluster) {
 			count
 			edges {
 				node {

--- a/api/generated.go
+++ b/api/generated.go
@@ -1944,7 +1944,11 @@ const GetScheduledJobs_Operation = `
 query GetScheduledJobs($slug: ID!, $agentQueryRules: [String!], $after: String) {
   organization(slug: $slug) {
     id
+<<<<<<< Updated upstream
     jobs(state: [SCHEDULED], type: [COMMAND], first: 100, after: $after, agentQueryRules: $agentQueryRules) {
+=======
+    jobs(state: [SCHEDULED], type: [COMMAND], first: 500, after: $after, agentQueryRules: $agentQueryRules) {
+>>>>>>> Stashed changes
       count
       edges {
         node {
@@ -1988,7 +1992,11 @@ func GetScheduledJobs(
 		Variables: &map[string]interface{}{
 			"slug":            slug,
 			"agentQueryRules": agentQueryRules,
+<<<<<<< Updated upstream
 			"first":           100,  // Fetch up to 100 jobs per page
+=======
+			"first":           500,  // Fetch up to 100 jobs per page
+>>>>>>> Stashed changes
 		},
 	}
 
@@ -2031,7 +2039,11 @@ func GetScheduledJobs(
 			Variables: &map[string]interface{}{
 				"slug":            slug,
 				"agentQueryRules": agentQueryRules,
+<<<<<<< Updated upstream
 				"first":           100,  // Fetch up to 100 jobs per page
+=======
+				"first":           500,  // Fetch up to 100 jobs per page
+>>>>>>> Stashed changes
 				"after":           *cursor, // Pass the cursor for pagination
 			},
 		}

--- a/api/generated.go
+++ b/api/generated.go
@@ -1944,11 +1944,7 @@ const GetScheduledJobs_Operation = `
 query GetScheduledJobs($slug: ID!, $agentQueryRules: [String!], $after: String) {
   organization(slug: $slug) {
     id
-<<<<<<< Updated upstream
-    jobs(state: [SCHEDULED], type: [COMMAND], first: 100, after: $after, agentQueryRules: $agentQueryRules) {
-=======
     jobs(state: [SCHEDULED], type: [COMMAND], first: 500, after: $after, agentQueryRules: $agentQueryRules) {
->>>>>>> Stashed changes
       count
       edges {
         node {
@@ -1992,11 +1988,7 @@ func GetScheduledJobs(
 		Variables: &map[string]interface{}{
 			"slug":            slug,
 			"agentQueryRules": agentQueryRules,
-<<<<<<< Updated upstream
-			"first":           100,  // Fetch up to 100 jobs per page
-=======
 			"first":           500,  // Fetch up to 100 jobs per page
->>>>>>> Stashed changes
 		},
 	}
 
@@ -2039,11 +2031,7 @@ func GetScheduledJobs(
 			Variables: &map[string]interface{}{
 				"slug":            slug,
 				"agentQueryRules": agentQueryRules,
-<<<<<<< Updated upstream
-				"first":           100,  // Fetch up to 100 jobs per page
-=======
 				"first":           500,  // Fetch up to 100 jobs per page
->>>>>>> Stashed changes
 				"after":           *cursor, // Pass the cursor for pagination
 			},
 		}

--- a/api/generated.go
+++ b/api/generated.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+	"log"
 
 	"github.com/Khan/genqlient/graphql"
 )
@@ -1019,6 +1020,12 @@ func (v *GetScheduledJobsOrganization) GetJobs() GetScheduledJobsOrganizationJob
 type GetScheduledJobsOrganizationJobsJobConnection struct {
 	Count int                                                         `json:"count"`
 	Edges []GetScheduledJobsOrganizationJobsJobConnectionEdgesJobEdge `json:"edges"`
+	PageInfo PageInfo                                                 `json:"pageInfo"`
+}
+
+type PageInfo struct {
+	HasNextPage bool `json:"hasNextPage"`
+	EndCursor   *string `json:"endCursor"`
 }
 
 // GetCount returns GetScheduledJobsOrganizationJobsJobConnection.Count, and is useful for accessing the field via an interface.
@@ -1642,7 +1649,7 @@ fragment Build on Build {
 	id
 	number
 	state
-	jobs(first: 500) {
+	jobs(first: 100) {
 		edges {
 			node {
 				__typename
@@ -1738,7 +1745,7 @@ fragment Build on Build {
 	id
 	number
 	state
-	jobs(first: 500) {
+	jobs(first: 100) {
 		edges {
 			node {
 				__typename
@@ -1805,7 +1812,7 @@ fragment Build on Build {
 	id
 	number
 	state
-	jobs(first: 500) {
+	jobs(first: 100) {
 		edges {
 			node {
 				__typename
@@ -1934,31 +1941,37 @@ func GetOrganization(
 
 // The query or mutation executed by GetScheduledJobs.
 const GetScheduledJobs_Operation = `
-query GetScheduledJobs ($slug: ID!, $agentQueryRules: [String!]) {
-	organization(slug: $slug) {
-		id
-		jobs(state: [SCHEDULED], type: [COMMAND], first: 500, order: RECENTLY_ASSIGNED, agentQueryRules: $agentQueryRules, clustered: false) {
-			count
-			edges {
-				node {
-					__typename
-					... Job
-				}
-			}
-		}
-	}
+query GetScheduledJobs($slug: ID!, $agentQueryRules: [String!], $after: String) {
+  organization(slug: $slug) {
+    id
+    jobs(state: [SCHEDULED], type: [COMMAND], first: 100, after: $after, agentQueryRules: $agentQueryRules) {
+      count
+      edges {
+        node {
+          __typename
+          ...Job
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
 }
+
 fragment Job on Job {
-	... on JobTypeCommand {
-		... CommandJob
-	}
+  ... on JobTypeCommand {
+    ...CommandJob
+  }
 }
+
 fragment CommandJob on JobTypeCommand {
-	uuid
-	env
-	scheduledAt
-	agentQueryRules
-	command
+  uuid
+  env
+  scheduledAt
+  agentQueryRules
+  command
 }
 `
 
@@ -1968,14 +1981,17 @@ func GetScheduledJobs(
 	slug string,
 	agentQueryRules []string,
 ) (*GetScheduledJobsResponse, error) {
+
 	req_ := &graphql.Request{
 		OpName: "GetScheduledJobs",
 		Query:  GetScheduledJobs_Operation,
-		Variables: &__GetScheduledJobsInput{
-			Slug:            slug,
-			AgentQueryRules: agentQueryRules,
+		Variables: &map[string]interface{}{
+			"slug":            slug,
+			"agentQueryRules": agentQueryRules,
+			"first":           100,  // Fetch up to 100 jobs per page
 		},
 	}
+
 	var err_ error
 
 	var data_ GetScheduledJobsResponse
@@ -1986,6 +2002,63 @@ func GetScheduledJobs(
 		req_,
 		resp_,
 	)
+	
+	log.Printf("data_: %v", data_.Organization.Jobs)	
+	
+	log.Printf("data_: %v", data_.Organization.Jobs.PageInfo)
+
+	hasNextPage := data_.Organization.Jobs.PageInfo.HasNextPage
+
+	log.Printf("hasNextPage: %v", hasNextPage)
+
+	if !hasNextPage {
+		return &data_, err_
+	}
+
+	cursor := data_.Organization.Jobs.PageInfo.EndCursor
+		
+	log.Printf("cursor: %v", *cursor)
+
+	for hasNextPage {
+		if cursor == nil {
+			log.Println("Cursor is nil, ending pagination.")
+			break
+		}
+
+		req_ := &graphql.Request{
+			OpName: "GetScheduledJobs",
+			Query:  GetScheduledJobs_Operation,
+			Variables: &map[string]interface{}{
+				"slug":            slug,
+				"agentQueryRules": agentQueryRules,
+				"first":           100,  // Fetch up to 100 jobs per page
+				"after":           *cursor, // Pass the cursor for pagination
+			},
+		}
+		
+		var tempResp GetScheduledJobsResponse
+
+		resp_ := &graphql.Response{Data: &tempResp}
+
+		err_ = client_.MakeRequest(ctx_, req_, resp_)
+		
+		if err_ != nil {
+			log.Printf("Error making paginated request: %v", err_)
+			return nil, err_
+		}
+		
+		log.Printf("tempResp: %v", tempResp.Organization.Jobs)	
+	
+		log.Printf("tempResp: %v", tempResp.Organization.Jobs.PageInfo)
+
+		hasNextPage = tempResp.Organization.Jobs.PageInfo.HasNextPage
+
+		log.Printf("hasNextPage: %v", hasNextPage)
+
+		data_.Organization.Jobs.Edges = append(data_.Organization.Jobs.Edges, tempResp.Organization.Jobs.Edges...)
+		
+		cursor = tempResp.Organization.Jobs.PageInfo.EndCursor
+	}
 
 	return &data_, err_
 }


### PR DESCRIPTION
This pull request introduces several improvements across the codebase, focusing on enhanced pagination for scheduled jobs, increased configurability for Kubernetes client settings, and minor dependency updates. The key changes are grouped below by theme.

**GraphQL Pagination and API Improvements:**

* Added robust pagination support to the `GetScheduledJobs` GraphQL query by introducing the `PageInfo` type, updating the query to accept an `after` cursor, and implementing logic to fetch all pages of jobs. This ensures that large job sets are retrieved reliably and efficiently. [[1]](diffhunk://#diff-7065552e1e75d34e0570a513b5d1b08ef842f83b2cf304f280b6f7bfd57f3243R1023-R1028) [[2]](diffhunk://#diff-7065552e1e75d34e0570a513b5d1b08ef842f83b2cf304f280b6f7bfd57f3243L1937-R1968) [[3]](diffhunk://#diff-7065552e1e75d34e0570a513b5d1b08ef842f83b2cf304f280b6f7bfd57f3243R1984-R1994)
* Increased the job fetch limit in `GetScheduledJobs` from 100 to 500 per page and in `GetScheduledJobsClustered` from 100 to 250, improving performance for organizations with many scheduled jobs. [[1]](diffhunk://#diff-7065552e1e75d34e0570a513b5d1b08ef842f83b2cf304f280b6f7bfd57f3243L1937-R1968) [[2]](diffhunk://#diff-7065552e1e75d34e0570a513b5d1b08ef842f83b2cf304f280b6f7bfd57f3243L1998-R2071)
* Added detailed logging for paginated job fetching to aid in debugging and monitoring of the job retrieval process.

**Kubernetes Client Configuration:**

* Introduced the `getEnvAsInt` helper to read integer environment variables, enabling dynamic configuration of `K8S_CLIENT_QPS` and `K8S_CLIENT_BURST` for the Kubernetes client. This allows tuning client request rates without code changes. [[1]](diffhunk://#diff-c49fd9cc751dfc13ff4e4cb0f8d8052514ccbf971a2f3068dced75539f959529R239-R251) [[2]](diffhunk://#diff-c49fd9cc751dfc13ff4e4cb0f8d8052514ccbf971a2f3068dced75539f959529R286-R290)

**Dependency and Build Updates:**

* Updated the build configuration in `.ko.yaml` to set the version string to a static value (`0.21.0`) instead of reading from the environment, ensuring consistent versioning in builds.

**Miscellaneous:**

* Added missing imports (`log`, `strconv`) for logging and environment variable parsing in relevant files. [[1]](diffhunk://#diff-7065552e1e75d34e0570a513b5d1b08ef842f83b2cf304f280b6f7bfd57f3243R10) [[2]](diffhunk://#diff-c49fd9cc751dfc13ff4e4cb0f8d8052514ccbf971a2f3068dced75539f959529R11)